### PR TITLE
refactor: 2.5.0 licensing updates and improvements with backwards compatibility

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -121,7 +121,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		$license = EDD_Software_Licensing::instance()->get_license( $license_id );
 
 		// Bailout if license does not found.
-		if ( ! $license ) {
+		if ( ! $license || ! $response['success'] ) {
 			return $response;
 		}
 

--- a/plugin.php
+++ b/plugin.php
@@ -142,7 +142,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		$response['current_version'] = get_post_meta( $download->ID, '_edd_sl_version', true );
 
 		// Set plugin slug if missing.
-		if( ! $response['item_name'] && $response['download_file'] ) {
+		if( ! $response['item_name'] ) {
 			$args['item_name'] = $response['item_name'] = str_replace(  ' ', '-', strtolower( edd_software_licensing()->get_download_name( $license_id ) ));
 			$response['license'] = edd_software_licensing()->get_download_version( $download->ID );
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -128,6 +128,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 		/* @var EDD_Download $license */
 		$download = $license->download;
 
+		$response['license_id']         = $license->ID;
+		$response['payment_id']         = $license->payment_id;
 		$response['download']           = '';
 		$response['is_all_access_pass'] = false;
 

--- a/plugin.php
+++ b/plugin.php
@@ -135,8 +135,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 				);
 
 				$remote_response = wp_remote_post(
-				// 'https://givewp.com/checkout/',
-					'http://staging.givewp.com/chekout/', // For testing purpose
+					home_url( '/checkout/' ),
 					array(
 						'timeout'   => 15,
 						'sslverify' => false,
@@ -154,8 +153,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 				if ( $response[ $license ]['check_license']['success'] ) {
 					$remote_response = wp_remote_post(
-					// 'https://givewp.com/checkout/',
-						'http://staging.givewp.com/chekout/', // For testing purpose
+						home_url( '/checkout/' ),
 						array(
 							'timeout'   => 15,
 							'sslverify' => false,

--- a/plugin.php
+++ b/plugin.php
@@ -283,6 +283,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 						$file['plugin_slug']     = basename( $file['file'], '.zip' );
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
 						$file['name']            = get_post_field( 'post_title', get_the_ID(), 'raw' );
+						$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
 						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
 						$response['download'][]  = $file;
 					}
@@ -306,7 +307,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 				$license->price_id
 			);
 
-			//$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
+			$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
 			$response['readme']          = get_post_meta( $download->ID, '_edd_readme_location', true );
 			$response['plugin_slug']     = basename( $download_file_info['file'], '.zip' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -40,10 +40,6 @@ if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE' ) ) {
 	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE', __FILE__ );
 }
 
-if ( ! defined( 'EDD_SL_VERSION' ) ) {
-	define( 'EDD_SL_VERSION', '0.1' );
-}
-
 // Do nothing if EDD Software Licensing plugin is not activated.
 $active_plugins = array_map( 'strtolower', get_option( 'active_plugins', array() ) );
 if ( ! in_array( 'edd-software-licensing/edd-software-licenses.php', $active_plugins, true ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -304,7 +304,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		header( 'Content-Type: application/json' );
 		echo wp_json_encode(
 			apply_filters(
-				'give_edd_remote_license_check_response',
+				'give_edd_remote_subscription_check_response',
 				array(
 					'success'     => ! empty( $subscriptions ),
 					'id'          => ! empty( $subscription['id'] ) ? absint( $subscription['id'] ) : '',

--- a/plugin.php
+++ b/plugin.php
@@ -246,9 +246,11 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 		// @todo: Maybe need to search by title.
 		if( ! $download->ID ) {
-			$the_query = new WP_Query(array(
-				's' => $item_name,
-				'posts_per_page' => 1
+			$the_query = new WP_Query( array(
+				's'              => $item_name,
+				'posts_per_page' => 1,
+				'posy_type'      => 'download',
+				'post_status'    => 'publish',
 			) );
 
 			// The Loop

--- a/plugin.php
+++ b/plugin.php
@@ -700,11 +700,10 @@ class Give_EDD_Software_Licensing_API_Extended {
 	public function acf_custom_thumbs_for_icons( $response, $download ) {
 
 		$featured_lowres = get_field( 'download_image', $download->ID );
-		$featured_highres = get_field( 'download_image_highres', $download->ID );
 
 		if( is_array( $featured_lowres ) ) {
 			$response['icons']['x1'] = $featured_lowres['sizes']['sl-small'];
-			$response['icons']['x2'] = $featured_highres['sizes']['sl-large'];
+			$response['icons']['x2'] = $featured_lowres['sizes']['sl-large'];
 
 			$response['icons'] = serialize( $response['icons'] );
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -591,12 +591,13 @@ class Give_EDD_Software_Licensing_API_Extended {
 			$response['plugin_slug']     = basename( dirname( $response['readme'] ) );
 
 			// Backward compatibility for subscription bundles.
-			$subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );
-			$response['subscription'] = array();
+			// @todo: as per devin, we should only check for license date instead of subscription date.
+			//$subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );
+			// $response['subscription'] = array();
 
-			if ( $subscription['status'] ) {
-				$response['subscription'] = $subscription;
-			}
+			// if ( $subscription['status'] ) {
+			// 	$response['subscription'] = $subscription;
+			// }
 		}
 
 		// Set plugin slug if missing.

--- a/plugin.php
+++ b/plugin.php
@@ -122,6 +122,12 @@ class Give_EDD_Software_Licensing_API_Extended {
 		/* @var EDD_SL_License $license */
 		$license = EDD_Software_Licensing::instance()->get_license( $license_id );
 
+
+		// Bailout if license does not found.
+		if( ! $license ) {
+			return $response;
+		}
+
 		/* @var EDD_Download $license */
 		$download = $license->download;
 

--- a/plugin.php
+++ b/plugin.php
@@ -727,5 +727,3 @@ add_action(
 		'plugin_setup',
 	)
 );
-
-// @todo : copied few function to decrease response time. discuss this with response time

--- a/plugin.php
+++ b/plugin.php
@@ -139,12 +139,12 @@ class Give_EDD_Software_Licensing_API_Extended {
 			$download->ID,
 			$license->price_id
 		);
-		$response['current_version'] = get_post_meta( $download->ID, '_edd_sl_version', true );
+		$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
 
 		// Set plugin slug if missing.
 		if( ! $response['item_name'] ) {
 			$args['item_name'] = $response['item_name'] = str_replace(  ' ', '-', strtolower( edd_software_licensing()->get_download_name( $license_id ) ));
-			$response['license'] = edd_software_licensing()->get_download_version( $download->ID );
+			$response['license'] = edd_software_licensing()->check_license( $args );
 		}
 
 		return $response;

--- a/plugin.php
+++ b/plugin.php
@@ -256,8 +256,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 						// Override exiting file url with protect download file url.
 						$file['plugin_slug']     = basename( $file['file'], '.zip' );
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
-						//$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
-						$file['name']            = str_replace( ' ', '-', strtolower( get_post_field( 'post_title', get_the_ID(), 'raw' ) ) );
+						$file['name']            = get_post_field( 'post_title', get_the_ID(), 'raw' );
 						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
 						$response['download'][]  = $file;
 					}

--- a/plugin.php
+++ b/plugin.php
@@ -433,6 +433,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @todo  : return result only if source set to give or something else because we do not want to sent extra information on every license check
 	 */
 	public function additional_license_checks( $response, $args, $license_id ) {
+		global $post;
+
 		// @todo: decide whether all access pass can be varibale priced if yes then how it will impect code..
 		// @todo: decide whether send this addition license data to only add-ons page of Give core.
 		// @todo discuss with devin that do we agree to deactivate license if it this request will come from non registered site
@@ -486,6 +488,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 				// print_r( $included_downloads );
 
 				if ( $included_downloads->have_posts() ) {
+					$tmp_post = $post;
+
 					while ( $included_downloads->have_posts() ) {
 						$included_downloads->the_post();
 
@@ -502,6 +506,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 						$response['download'][]  = $file;
 					}
 
+					// Temporary hack: some global $post keep remain to last item in loop which set wrong item name to last license.
+					$post = $tmp_post;
 					wp_reset_postdata();
 				}
 			}

--- a/plugin.php
+++ b/plugin.php
@@ -117,6 +117,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 	public function remote_license_check( $response, $args, $license_id ) {
 		// @todo: decide whether all access pass can be varibale priced if yes then how it will impect code..
 		// @todo: decide whether send this addition license data to only add-ons page of Give core.
+		// @todo discuss with devin that do we agree to deactivate license if it this request will come from non registered site
 		/* @var EDD_SL_License $license */
 		$license = EDD_Software_Licensing::instance()->get_license( $license_id );
 

--- a/plugin.php
+++ b/plugin.php
@@ -133,7 +133,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		}
 
 		$response['download_file'] = edd_get_download_file_url(
-			$license->key,
+			edd_get_payment_key( $license->payment_id ), // @todo: which payment id we need to pass if multiple payment happen.
 			$response['customer_email'],
 			$download_file_info['index'],
 			$download->ID,

--- a/plugin.php
+++ b/plugin.php
@@ -699,7 +699,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 */
 	public function acf_custom_thumbs_for_icons( $response, $download ) {
 
-		$featured_lowres = get_field( 'download_image', $download->ID );
+		$featured_lowres = get_field( 'download_icon', $download->ID );
 
 		if( is_array( $featured_lowres ) ) {
 			$response['icons']['x1'] = $featured_lowres['sizes']['sl-small'];

--- a/plugin.php
+++ b/plugin.php
@@ -212,7 +212,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 		// Set plugin slug if missing.
 		if ( ! $response['item_name'] ) {
-			$args['item_name']   = $response['item_name'] = str_replace( ' ', '-', strtolower( edd_software_licensing()->get_download_name( $license_id ) ) );
+			$args['item_name']   = $response['item_name'] = edd_software_licensing()->get_download_name( $license_id );
 			$response['license'] = edd_software_licensing()->check_license( $args );
 		}
 

--- a/plugin.php
+++ b/plugin.php
@@ -99,7 +99,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 		add_filter( 'edd_remote_license_check_response', array( $this, 'additional_license_checks' ), 10, 3 );
 		add_action( 'edd_check_subscription', array( $this, 'remote_subscription_check' ) );
 		add_action( 'edd_check_licenses', array( $this, 'remote_licenses_check' ) );
-		add_filter( 'edd_sl_get_addon_info', 'edd_sl_readme_modify_license_response', 10, 3 );
 	}
 
 	/**

--- a/plugin.php
+++ b/plugin.php
@@ -98,7 +98,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 		add_filter( 'edd_remote_license_check_response', array( $this, 'additional_license_checks' ), 10, 3 );
 		add_action( 'edd_check_subscription', array( $this, 'remote_subscription_check' ) );
 		add_action( 'edd_check_licenses', array( $this, 'remote_licenses_check' ) );
-		add_action( 'edd_get_addons_info', array( $this, 'remote_get_addons_info' ) );
 		add_filter( 'edd_sl_get_addon_info', 'edd_sl_readme_modify_license_response', 10, 3 );
 	}
 
@@ -715,82 +714,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 			)
 		);
 
-		exit;
-	}
-
-
-	/**
-	 * Get addons information
-	 */
-	public function remote_get_addons_info() {
-		$addon_list = array_map( function ( $addon_name ) {
-			return trim( sanitize_text_field( rawurldecode( $addon_name ) ) );
-		}, explode( ',', $_REQUEST['addons'] ) );
-
-
-		$addon_list = $addon_list ? array_filter( $addon_list ) : array();
-
-
-		$response = array();
-
-		// set content type of response
-		header( 'Content-Type: application/json' );
-
-		if ( ! $addon_list ) {
-			$response['msg'] = __( 'No item provided', 'edd_sl' );
-			echo json_encode( $response );
-			exit;
-		}
-
-		foreach ( $addon_list as $item_name ) {
-			$item_id = edd_software_licensing()->get_download_id_by_name( $item_name );
-
-			$download = new EDD_SL_Download( $item_id );
-
-			if ( ! $download->ID ) {
-				continue;
-			}
-
-			$file           = $this->get_latest_release( $download->files );
-			$plugin_slug    = basename( $file['file'], '.zip' );
-			$stable_version = $version = edd_software_licensing()->get_latest_version( $item_id );
-			$description    = ! empty( $download->post_excerpt ) ? $download->post_excerpt : $download->post_content;
-			$changelog      = $download->get_changelog();
-
-			$tmp = array(
-				'new_version'      => $version,
-				'stable_version'   => $stable_version,
-				'plugin_shortname' => $item_name,
-				'name'             => $download->post_title,
-				'slug'             => $download->post_name,
-				'plugin_slug'      => $plugin_slug,
-				'homepage'         => get_permalink( $item_id ),
-				'sections'         => serialize(
-					array(
-						'description' => wpautop( strip_tags( $description, '<p><li><ul><ol><strong><a><em><span><br>' ) ),
-						'changelog'   => wpautop( strip_tags( stripslashes( $changelog ), '<p><li><ul><ol><strong><a><em><span><br>' ) ),
-					)
-				),
-			);
-
-			$tmp = apply_filters( 'edd_sl_get_addon_info', $tmp, $download );
-
-			/**
-			 * Encode any emoji in the name and sections.
-			 *
-			 * @see   https://github.com/easydigitaldownloads/EDD-Software-Licensing/issues/1313
-			 */
-			if ( function_exists( 'wp_encode_emoji' ) ) {
-				$tmp['name'] = wp_encode_emoji( $tmp['name'] );
-
-				$sections        = maybe_unserialize( $tmp['sections'] );
-				$tmp['sections'] = serialize( array_map( 'wp_encode_emoji', $sections ) );
-			}
-
-			$response[] = $tmp;
-		}
-
-		echo json_encode( $response );
 		exit;
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -3,8 +3,8 @@
  * Plugin Name: Give EDD Software Licensing API Extended
  * Plugin URI: https://givewp.com
  * Description: Add more api endpoints for Easy Digital Downloads - Software Licenses.
- * Author: WordImpress
- * Author URI: https://wordimpress.com
+ * Author: GiveWP
+ * Author URI: https://givewp.com
  * Version: 0.2
  *
  * Give EDD Software Licensing API Extended is free software: you can redistribute it and/or modify
@@ -28,17 +28,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_DIR' ) ) {
-	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-}
-
-if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_URL' ) ) {
-	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-}
-
 if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE' ) ) {
 	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE', __FILE__ );
 }
+
+if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_DIR' ) ) {
+	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_DIR', plugin_dir_path( GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE ) );
+}
+
+if ( ! defined( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_URL' ) ) {
+	define( 'GIVE_EDD_SL_API_EXTENDED_PLUGIN_URL', plugin_dir_url( GIVE_EDD_SL_API_EXTENDED_PLUGIN_FILE ) );
+}
+
 
 // Do nothing if EDD Software Licensing plugin is not activated.
 $active_plugins = array_map( 'strtolower', get_option( 'active_plugins', array() ) );

--- a/plugin.php
+++ b/plugin.php
@@ -301,19 +301,42 @@ class Give_EDD_Software_Licensing_API_Extended {
 			}
 		}
 
+		return array(
+			'success'     => ! empty( $subscriptions ),
+			'id'          => ! empty( $subscription['id'] ) ? absint( $subscription['id'] ) : '',
+			'license_key' => $license_key,
+			'status'      => ! empty( $subscription['status'] ) ? $subscription['status'] : '',
+			'expires'     => ! empty( $subscription['expiration'] )
+				? (
+				is_numeric( $subscription['expiration'] )
+					? date( 'Y-m-d H:i:s', $subscription['expiration'] )
+					: $subscription['expiration']
+				)
+				: '',
+			'payment_id'  => $payment_id,
+			'invoice_url' => urlencode( add_query_arg( 'payment_key', edd_get_payment_key( $payment_id ), edd_get_success_page_uri() ) ),
+		);
+	}
+
+
+	/**
+	 * Check subscription for addon
+	 *
+	 * @param array $data Api request data.
+	 *
+	 * @return void
+	 * @since  0.1
+	 * @access public
+	 *
+	 */
+	function remote_subscription_check( $data ) {
+		$license = edd_software_licensing()->get_license( urldecode( $data['license'] ), true );
+
 		header( 'Content-Type: application/json' );
 		echo wp_json_encode(
 			apply_filters(
 				'give_edd_remote_subscription_check_response',
-				array(
-					'success'     => ! empty( $subscriptions ),
-					'id'          => ! empty( $subscription['id'] ) ? absint( $subscription['id'] ) : '',
-					'license_key' => $license_key,
-					'status'      => ! empty( $subscription['status'] ) ? $subscription['status'] : '',
-					'expires'     => ! empty( $subscription['expiration'] ) ? ( is_numeric( $subscription['expiration'] ) ? date( 'Y-m-d H:i:s', $subscription['expiration'] ) : $subscription['expiration'] ) : '',
-					'payment_id'  => $payment_id,
-					'invoice_url' => urlencode( add_query_arg( 'payment_key', edd_get_payment_key( $payment_id ), edd_get_success_page_uri() ) ),
-				),
+				$this->subscription_check( $data ),
 				$data,
 				$license
 			)

--- a/plugin.php
+++ b/plugin.php
@@ -128,6 +128,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		/* @var EDD_Download $license */
 		$download = $license->download;
 
+		$response['license_key']        = $args['key'];
 		$response['license_id']         = $license->ID;
 		$response['payment_id']         = $license->payment_id;
 		$response['download']           = '';

--- a/plugin.php
+++ b/plugin.php
@@ -391,7 +391,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 								)
 							);
 
-							$response[ $license ]['get_versions'][] = $remote_response;
+							$response[ $license ]['get_versions'][] = $remote_response['new_version'] ? $remote_response : array();
 						}
 					} else {
 						$remote_response = $this->get_latest_version_remote_copy(
@@ -404,7 +404,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 							)
 						);
 
-						$response[ $license ]['get_version'] = $remote_response;
+						$response[ $license ]['get_version'] =  $remote_response['new_version'] ? $remote_response : array();
 					}
 				}
 			}

--- a/plugin.php
+++ b/plugin.php
@@ -258,7 +258,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 						// Override exiting file url with protect download file url.
 						$file['plugin_slug']     = basename( $file['file'], '.zip' );
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
-						$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
+						//$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
 						$file['name']            = str_replace( ' ', '-', strtolower( get_post_field( 'post_title', get_the_ID(), 'raw' ) ) );
 						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
 						$response['download'][]  = $file;
@@ -283,7 +283,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 				$license->price_id
 			);
 
-			$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
+			//$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
 			$response['readme']          = get_post_meta( $download->ID, '_edd_readme_location', true );
 			$response['plugin_slug']     = basename( $download_file_info['file'], '.zip' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -498,11 +498,11 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 						// @todo by default this function set price id to default variable price if any . revalidate this if it will create any issue or not
 						// Override exiting file url with protect download file url.
-						$file['plugin_slug']     = basename( $file['file'], '.zip' );
+						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
+						$file['plugin_slug']     = basename( dirname( $file['readme'] ) );
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
 						$file['name']            = get_post_field( 'post_title', get_the_ID(), 'raw' );
 						$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
-						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
 						$response['download'][]  = $file;
 					}
 
@@ -529,7 +529,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 			$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
 			$response['readme']          = get_post_meta( $download->ID, '_edd_readme_location', true );
-			$response['plugin_slug']     = basename( $download_file_info['file'], '.zip' );
+			$response['plugin_slug']     = basename( dirname( $response['readme'] ) );
 
 			// Backward compatibility for subscription bundles.
 			$subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );

--- a/plugin.php
+++ b/plugin.php
@@ -174,9 +174,11 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 						// @todo by default this function set price id to default variable price if any . revalidate this if it will create any issue or not
 						// Override exiting file url with protect download file url.
+						$file['plugin_slug']     = basename( $file['file'], '.zip' );
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
 						$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
-						$file['name']            = get_post_field( 'post_title', get_the_ID(), 'raw' );
+						$file['name']            = str_replace( ' ', '-', strtolower( get_post_field( 'post_title', get_the_ID(), 'raw' ) ) );
+						$file['readme']          = get_post_meta( get_the_ID(), '_edd_readme_location', true );
 						$response['download'][]  = $file;
 					}
 
@@ -200,6 +202,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 			);
 
 			$response['current_version'] = edd_software_licensing()->get_download_version( $download->ID );
+			$response['readme']          = get_post_meta( $download->ID, '_edd_readme_location', true );
+			$response['plugin_slug']     = basename( $download_file_info['file'], '.zip' );
 
 			// Backward compatibility for subscription bundles.
 			$subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );

--- a/plugin.php
+++ b/plugin.php
@@ -681,3 +681,5 @@ add_action(
 		'plugin_setup',
 	)
 );
+
+// @todo : copied few function to decrease response time. discuss this with response time

--- a/plugin.php
+++ b/plugin.php
@@ -245,13 +245,15 @@ class Give_EDD_Software_Licensing_API_Extended {
 		$download = new EDD_SL_Download( $item_id );
 
 		// @todo: Maybe need to search by title.
-		if( ! $download->ID ) {
-			$the_query = new WP_Query( array(
-				's'              => $item_name,
-				'posts_per_page' => 1,
-				'posy_type'      => 'download',
-				'post_status'    => 'publish',
-			) );
+		if ( ! $download->ID ) {
+			$the_query = new WP_Query(
+				array(
+					's'              => $item_name,
+					'posts_per_page' => 1,
+					'posy_type'      => 'download',
+					'post_status'    => 'publish',
+				)
+			);
 
 			// The Loop
 			if ( $the_query->have_posts() ) {
@@ -287,7 +289,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 		}
 
 		$stable_version = $version = edd_software_licensing()->get_latest_version( $item_id );
-		$slug           = ! empty( $slug ) ? $slug :basename( dirname( get_post_meta( $download->ID, '_edd_readme_location', true ) ) );
+		$slug           = ! empty( $slug ) ? $slug : basename( dirname( get_post_meta( $download->ID, '_edd_readme_location', true ) ) );
 		$description    = ! empty( $download->post_excerpt ) ? $download->post_excerpt : $download->post_content;
 		$changelog      = $download->get_changelog();
 
@@ -457,7 +459,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 						'edd_action' => 'get_version',
 						'url'        => $args['url'],
 						'item_name'  => $addon,
-						//'slug'       => $response[ $license ]['check_license']['plugin_slug'],
+						// 'slug'       => $response[ $license ]['check_license']['plugin_slug'],
 					)
 				);
 
@@ -545,7 +547,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 				);
 
 				// print_r( $included_downloads );
-
 				if ( $included_downloads->have_posts() ) {
 					$tmp_post = $post;
 
@@ -592,11 +593,10 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 			// Backward compatibility for subscription bundles.
 			// @todo: as per devin, we should only check for license date instead of subscription date.
-			//$subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );
+			// $subscription             = $this->subscription_check( array( 'license' => $args['key'] ) );
 			// $response['subscription'] = array();
-
 			// if ( $subscription['status'] ) {
-			// 	$response['subscription'] = $subscription;
+			// $response['subscription'] = $subscription;
 			// }
 		}
 

--- a/plugin.php
+++ b/plugin.php
@@ -176,6 +176,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 						// Override exiting file url with protect download file url.
 						$file['file']            = edd_all_access_product_download_url( $included_download->ID, 0, $file['array_index'] );
 						$file['current_version'] = edd_software_licensing()->get_download_version( $included_download->ID );
+						$file['name']            = get_post_field( 'post_title', get_the_ID(), 'raw' );
 						$response['download'][]  = $file;
 					}
 

--- a/plugin.php
+++ b/plugin.php
@@ -96,6 +96,7 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 */
 	public function plugin_setup() {
 		add_filter( 'edd_sl_license_response', array( $this, 'additional_license_response_checks' ), 10, 1 );
+		add_filter( 'edd_sl_license_response', array( $this, 'acf_custom_thumbs_for_icons' ), 11, 2 );
 		add_filter( 'edd_remote_license_check_response', array( $this, 'additional_license_checks' ), 10, 3 );
 		add_action( 'edd_check_subscription', array( $this, 'remote_subscription_check' ) );
 		add_action( 'edd_check_licenses', array( $this, 'remote_licenses_check' ) );
@@ -684,6 +685,32 @@ class Give_EDD_Software_Licensing_API_Extended {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Use the ACF custom field for plugin update thumbnail images.
+	 *
+	 * This allows us to use the feature image option for the download post type for the add-on listing page and on single downloads and doesn't restrict us to a square size.
+	 *
+	 * @param array $response
+	 * @param EDD_Download $download
+	 *
+	 * @return array $response
+	 */
+	public function acf_custom_thumbs_for_icons( $response, $download ) {
+
+		$featured_lowres = get_field( 'download_image', $download->ID );
+		$featured_highres = get_field( 'download_image_highres', $download->ID );
+
+		if( is_array( $featured_lowres ) ) {
+			$response['icons']['x1'] = $featured_lowres['sizes']['sl-small'];
+			$response['icons']['x2'] = $featured_highres['sizes']['sl-large'];
+
+			$response['icons'] = serialize( $response['icons'] );
+		}
+
+		return $response;
+
 	}
 
 	/**

--- a/plugin.php
+++ b/plugin.php
@@ -76,7 +76,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @since   0.1
 	 * @access  public
 	 * @wp-hook plugins_loaded
-	 *
 	 */
 	public static function get_instance() {
 		if ( null === static::$instance ) {
@@ -93,12 +92,245 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @since   0.1
 	 * @access  public
 	 * @wp-hook plugins_loaded
-	 *
 	 */
 	public function plugin_setup() {
-		add_filter( 'edd_remote_license_check_response', array( $this, 'remote_license_check' ), 10, 3 );
+		add_filter( 'edd_remote_license_check_response', array( $this, 'additional_license_checks' ), 10, 3 );
 		add_action( 'edd_check_subscription', array( $this, 'remote_subscription_check' ) );
 		add_action( 'edd_check_licenses', array( $this, 'remote_licenses_check' ) );
+	}
+
+	/**
+	 * Given an array of arguments, sort them by length, and then md5 them to generate a checksum.
+	 * Note: this function copied from EDD_Software_Licensing to descrease response time when do bulk licenses check
+	 *
+	 * @param array $args
+	 *
+	 * @return string
+	 * @since 3.5
+	 */
+	private function get_request_checksum_copy( $args = array() ) {
+		usort( $args, array( $this, 'sort_args_by_length' ) );
+		$string_args = json_encode( $args );
+
+		return md5( $string_args );
+	}
+
+	/**
+	 * License check
+	 * Note: this function copied from EDD_Software_Licensing to descrease response time when do bulk licenses check
+	 *
+	 * Modification list:
+	 * 1. return array instead of json
+	 *
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	function remote_license_check_copy( $data ) {
+
+		$item_id   = ! empty( $data['item_id'] ) ? absint( $data['item_id'] ) : false;
+		$item_name = ! empty( $data['item_name'] ) ? rawurldecode( $data['item_name'] ) : false;
+		$license   = isset( $data['license'] ) ? urldecode( $data['license'] ) : false;
+		$url       = isset( $data['url'] ) ? urldecode( $data['url'] ) : '';
+
+		$args = array(
+			'item_id'   => $item_id,
+			'item_name' => $item_name,
+			'key'       => $license,
+			'url'       => $url,
+		);
+
+		$result   = $message = edd_software_licensing()->check_license( $args );
+		$checksum = $this->get_request_checksum_copy( $args );
+
+		if ( 'invalid' === $result ) {
+			$result = false;
+		}
+
+		$response = array();
+		if ( false !== $result ) {
+			$license = edd_software_licensing()->get_license( $license, true );
+
+			$response['expires']          = is_numeric( $license->expiration ) ? date( 'Y-m-d H:i:s', $license->expiration ) : $license->expiration;
+			$response['payment_id']       = $license->payment_id;
+			$response['customer_name']    = $license->customer->name;
+			$response['customer_email']   = $license->customer->email;
+			$response['license_limit']    = $license->activation_limit;
+			$response['site_count']       = $license->activation_count;
+			$response['activations_left'] = $license->activation_limit > 0 ? $license->activation_limit - $license->activation_count : 'unlimited';
+			$response['price_id']         = $license->price_id;
+		}
+
+		if ( empty( $item_name ) ) {
+			$item_name = get_the_title( $item_id );
+		}
+
+		$response = array_merge(
+			array(
+				'success'   => (bool) $result,
+				'license'   => $message,
+				'item_id'   => $item_id,
+				'item_name' => $item_name,
+				'checksum'  => $checksum,
+			),
+			$response
+		);
+
+		$license_id = ! empty( $license->ID ) ? $license->ID : false;
+
+		return apply_filters( 'edd_remote_license_check_response', $response, $args, $license_id );
+	}
+
+	/**
+	 * Version Check
+	 * Note: this function copied from EDD_Software_Licensing to descrease response time when do bulk licenses check
+	 *
+	 * Modification list:
+	 * 1. return array instead of json
+	 *
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	function get_latest_version_remote_copy( $data ) {
+
+		$url       = isset( $data['url'] ) ? sanitize_text_field( urldecode( $data['url'] ) ) : false;
+		$license   = isset( $data['license'] ) ? sanitize_text_field( urldecode( $data['license'] ) ) : false;
+		$slug      = isset( $data['slug'] ) ? sanitize_text_field( urldecode( $data['slug'] ) ) : false;
+		$item_id   = isset( $data['item_id'] ) ? absint( $data['item_id'] ) : false;
+		$item_name = isset( $data['item_name'] ) ? sanitize_text_field( rawurldecode( $data['item_name'] ) ) : false;
+		$beta      = isset( $data['beta'] ) ? (bool) $data['beta'] : false;
+		if ( empty( $item_name ) && empty( $item_id ) ) {
+			$item_name = isset( $data['name'] ) ? sanitize_text_field( rawurldecode( $data['name'] ) ) : false;
+		}
+
+		$response = array(
+			'new_version'    => '',
+			'stable_version' => '',
+			'sections'       => '',
+			'license_check'  => '',
+			'msg'            => '',
+		);
+
+		if ( empty( $item_id ) && empty( $item_name ) && ( ! defined( 'EDD_BYPASS_NAME_CHECK' ) || ! EDD_BYPASS_NAME_CHECK ) ) {
+			$response['msg'] = __( 'No item provided', 'edd_sl' );
+
+			return $response;
+		}
+
+		if ( empty( $item_id ) ) {
+
+			if ( empty( $license ) && empty( $item_name ) ) {
+				$response['msg'] = __( 'No item provided', 'edd_sl' );
+				return $response;
+			}
+
+			$check_by_name_first = apply_filters( 'edd_sl_force_check_by_name', false );
+
+			if ( empty( $license ) || $check_by_name_first ) {
+
+				$item_id = edd_software_licensing()->get_download_id_by_name( $item_name );
+
+			} else {
+
+				$item_id = edd_software_licensing()->get_download_id_by_license( $license );
+
+			}
+		}
+
+		$download = new EDD_SL_Download( $item_id );
+
+		if ( ! $download ) {
+
+			if ( empty( $license ) || $check_by_name_first ) {
+				$response['msg'] = sprintf( __( 'Item name provided does not match a valid %s', 'edd_sl' ), edd_get_label_singular() );
+			} else {
+				$response['msg'] = sprintf( __( 'License key provided does not match a valid %s', 'edd_sl' ), edd_get_label_singular() );
+			}
+
+			return $response;
+		}
+
+		$is_valid_for_download = edd_software_licensing()->is_download_id_valid_for_license( $download->ID, $license );
+		if ( ! empty( $license ) && ( ! defined( 'EDD_BYPASS_NAME_CHECK' ) || ! EDD_BYPASS_NAME_CHECK ) && ( ! $is_valid_for_download || ( ! empty( $item_name ) && ! edd_software_licensing()->check_item_name( $download->ID, $item_name, $license ) ) ) ) {
+
+			$download_name   = ! empty( $item_name ) ? $item_name : $download->get_name();
+			$response['msg'] = sprintf( __( 'License key is not valid for %s', 'edd_sl' ), $download_name );
+
+			return $response;
+		}
+
+		$stable_version = $version = edd_software_licensing()->get_latest_version( $item_id );
+		$slug           = ! empty( $slug ) ? $slug : $download->post_name;
+		$description    = ! empty( $download->post_excerpt ) ? $download->post_excerpt : $download->post_content;
+		$changelog      = $download->get_changelog();
+
+		$download_beta = false;
+		if ( $beta && $download->has_beta() ) {
+			$version_beta = edd_software_licensing()->get_beta_download_version( $item_id );
+			if ( version_compare( $version_beta, $stable_version, '>' ) ) {
+				$changelog     = $download->get_beta_changelog();
+				$version       = $version_beta;
+				$download_beta = true;
+			}
+		}
+
+		$response = array(
+			'new_version'    => $version,
+			'stable_version' => $stable_version,
+			'name'           => $download->post_title,
+			'slug'           => $slug,
+			'url'            => esc_url( add_query_arg( 'changelog', '1', get_permalink( $item_id ) ) ),
+			'last_updated'   => $download->post_modified,
+			'homepage'       => get_permalink( $item_id ),
+			'package'        => edd_software_licensing()->get_encoded_download_package_url( $item_id, $license, $url, $download_beta ),
+			'download_link'  => edd_software_licensing()->get_encoded_download_package_url( $item_id, $license, $url, $download_beta ),
+			'sections'       => serialize(
+				array(
+					'description' => wpautop( strip_tags( $description, '<p><li><ul><ol><strong><a><em><span><br>' ) ),
+					'changelog'   => wpautop( strip_tags( stripslashes( $changelog ), '<p><li><ul><ol><strong><a><em><span><br>' ) ),
+				)
+			),
+			'banners'        => serialize(
+				array(
+					'high' => get_post_meta( $item_id, '_edd_readme_plugin_banner_high', true ),
+					'low'  => get_post_meta( $item_id, '_edd_readme_plugin_banner_low', true ),
+				)
+			),
+			'icons'          => array(),
+		);
+
+		if ( has_post_thumbnail( $download->ID ) ) {
+			$thumb_id  = get_post_thumbnail_id( $download->ID );
+			$thumb_128 = get_the_post_thumbnail_url( $download->ID, 'sl-small' );
+			if ( ! empty( $thumb_128 ) ) {
+				$response['icons']['1x'] = $thumb_128;
+			}
+
+			$thumb_256 = get_the_post_thumbnail_url( $download->ID, 'sl-large' );
+			if ( ! empty( $thumb_256 ) ) {
+				$response['icons']['2x'] = $thumb_256;
+			}
+		}
+
+		$response['icons'] = serialize( $response['icons'] );
+
+		$response = apply_filters( 'edd_sl_license_response', $response, $download, $download_beta );
+
+		/**
+		 * Encode any emoji in the name and sections.
+		 *
+		 * @since 3.6.5
+		 * @see   https://github.com/easydigitaldownloads/EDD-Software-Licensing/issues/1313
+		 */
+		if ( function_exists( 'wp_encode_emoji' ) ) {
+			$response['name'] = wp_encode_emoji( $response['name'] );
+
+			$sections             = maybe_unserialize( $response['sections'] );
+			$response['sections'] = serialize( array_map( 'wp_encode_emoji', $sections ) );
+		}
+
+		return $response;
 	}
 
 
@@ -109,8 +341,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 */
 	public function remote_licenses_check( $args ) {
 		$defaults = array(
-			'licenses'  => '',
-			'url'       => '',
+			'licenses' => '',
+			'url'      => '',
 		);
 
 		$args             = array_map( 'sanitize_text_field', $args );
@@ -135,70 +367,47 @@ class Give_EDD_Software_Licensing_API_Extended {
 					'get_versions'  => array(),
 				);
 
-				$remote_response = wp_remote_post(
-					home_url( '/checkout/' ),
+				$remote_response = $this->remote_license_check_copy(
 					array(
-						'timeout'   => 15,
-						'sslverify' => false,
-						'body'      => array(
-							'edd_action' => 'check_license',
-							'license'    => $license,
-							'url'        => $args['url'],
-						),
+						'edd_action' => 'check_license',
+						'license'    => $license,
+						'url'        => $args['url'],
 					)
 				);
 
-				$response[ $license ]['check_license'] = ! is_wp_error( $remote_response )
-					? json_decode( wp_remote_retrieve_body( $remote_response ), true )
-					: $remote_response;
+				$response[ $license ]['check_license'] = $remote_response;
 
 				if ( $response[ $license ]['check_license']['success'] ) {
-					if( $response[ $license ]['check_license']['is_all_access_pass'] ){
+					if ( $response[ $license ]['check_license']['is_all_access_pass'] ) {
 						foreach ( $response[ $license ]['check_license']['download'] as $download ) {
-							$remote_response = wp_remote_post(
-								home_url( '/checkout/' ),
+							$remote_response = $this->get_latest_version_remote_copy(
 								array(
-									'timeout'   => 15,
-									'sslverify' => false,
-									'body'      => array(
-										'edd_action' => 'get_version',
-										'license'    => $license,
-										'url'        => $args['url'],
-										'item_name'  => $download['name'],
-										'slug'       => $download['plugin_slug'],
-									)
-								)
-							);
-
-							$response[ $license ]['get_versions'][] = ! is_wp_error( $remote_response )
-								? json_decode( wp_remote_retrieve_body( $remote_response ), true )
-								: $remote_response;
-						}
-
-					} else{
-						$remote_response = wp_remote_post(
-							home_url( '/checkout/' ),
-							array(
-								'timeout'   => 15,
-								'sslverify' => false,
-								'body'      => array(
 									'edd_action' => 'get_version',
 									'license'    => $license,
 									'url'        => $args['url'],
-									'item_name'  => $response[ $license ]['check_license']['item_name'],
-									'slug'       => $response[ $license ]['check_license']['plugin_slug'],
-								),
+									'item_name'  => $download['name'],
+									'slug'       => $download['plugin_slug'],
+								)
+							);
+
+							$response[ $license ]['get_versions'][] = $remote_response;
+						}
+					} else {
+						$remote_response = $this->get_latest_version_remote_copy(
+							array(
+								'edd_action' => 'get_version',
+								'license'    => $license,
+								'url'        => $args['url'],
+								'item_name'  => $response[ $license ]['check_license']['item_name'],
+								'slug'       => $response[ $license ]['check_license']['plugin_slug'],
 							)
 						);
 
-						$response[ $license ]['get_version'] = ! is_wp_error( $remote_response )
-							? json_decode( wp_remote_retrieve_body( $remote_response ), true )
-							: $remote_response;
+						$response[ $license ]['get_version'] = $remote_response;
 					}
 				}
 			}
 		}
-
 
 		header( 'Content-Type: application/json' );
 		echo wp_json_encode( $response );
@@ -218,9 +427,8 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @since 0.3
 	 *
 	 * @todo  : return result only if source set to give or something else because we do not want to sent extra information on every license check
-	 *
 	 */
-	public function remote_license_check( $response, $args, $license_id ) {
+	public function additional_license_checks( $response, $args, $license_id ) {
 		// @todo: decide whether all access pass can be varibale priced if yes then how it will impect code..
 		// @todo: decide whether send this addition license data to only add-ons page of Give core.
 		// @todo discuss with devin that do we agree to deactivate license if it this request will come from non registered site
@@ -256,18 +464,20 @@ class Give_EDD_Software_Licensing_API_Extended {
 			if ( ! empty( $all_access_pass->all_access_meta['all_access_categories'] ) ) {
 				$response['download'] = array();
 
-				$included_downloads = new WP_Query( array(
-					'post_type'      => 'download',
-					'post_status'    => 'publish',
-					'tax_query'      => array(
-						array(
-							'taxonomy' => 'download_category',
-							'field'    => 'term_id',
-							'terms'    => $all_access_pass->all_access_meta['all_access_categories'],
+				$included_downloads = new WP_Query(
+					array(
+						'post_type'      => 'download',
+						'post_status'    => 'publish',
+						'tax_query'      => array(
+							array(
+								'taxonomy' => 'download_category',
+								'field'    => 'term_id',
+								'terms'    => $all_access_pass->all_access_meta['all_access_categories'],
+							),
 						),
-					),
-					'posts_per_page' => - 1,
-				) );
+						'posts_per_page' => - 1,
+					)
+				);
 
 				// print_r( $included_downloads );
 
@@ -337,7 +547,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 *
 	 * @return array
 	 * @since 0.3
-	 *
 	 */
 	private function get_latest_release( $download_files ) {
 		if ( empty( $download_files ) ) {
@@ -378,7 +587,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @return array|object|null Subscription data
 	 * @since  0.1
 	 * @access public
-	 *
 	 */
 	function get_subscription( $payment_id ) {
 		global $wpdb;
@@ -446,7 +654,6 @@ class Give_EDD_Software_Licensing_API_Extended {
 	 * @return void
 	 * @since  0.1
 	 * @access public
-	 *
 	 */
 	function remote_subscription_check( $data ) {
 		$license = edd_software_licensing()->get_license( urldecode( $data['license'] ), true );

--- a/plugin.php
+++ b/plugin.php
@@ -244,6 +244,26 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 		$download = new EDD_SL_Download( $item_id );
 
+		// @todo: Maybe need to search by title.
+		if( ! $download->ID ) {
+			$the_query = new WP_Query(array(
+				's' => $item_name,
+				'posts_per_page' => 1
+			) );
+
+			// The Loop
+			if ( $the_query->have_posts() ) {
+
+				while ( $the_query->have_posts() ) {
+					$the_query->the_post();
+
+					$download = new EDD_SL_Download( get_the_ID() );
+				}
+
+				wp_reset_postdata();
+			}
+		}
+
 		if ( ! $download ) {
 
 			if ( empty( $license ) || $check_by_name_first ) {

--- a/plugin.php
+++ b/plugin.php
@@ -276,21 +276,14 @@ class Give_EDD_Software_Licensing_API_Extended {
 
 
 	/**
-	 * Check subscription for addon
+	 * Get subscription information
 	 *
-	 * @param array $data Api request data.
+	 * @param array $data
 	 *
-	 * @return void
-	 * @since  0.1
-	 * @access public
-	 *
+	 * @return array
 	 */
-	function remote_subscription_check( $data ) {
-
-		$item_id     = ! empty( $data['item_id'] ) ? absint( $data['item_id'] ) : false;
-		$item_name   = ! empty( $data['item_name'] ) ? rawurldecode( $data['item_name'] ) : false;
+	private function subscription_check( $data ) {
 		$license_key = urldecode( $data['license'] );
-		$url         = isset( $data['url'] ) ? urldecode( $data['url'] ) : '';
 		$license     = edd_software_licensing()->get_license( $license_key, true );
 
 		$subscriptions = array();


### PR DESCRIPTION
## PR Description

This updates the Give -> EDD Software Licensing functionality on `givewp.com` and `staginng.givewp.com`

Currently, this code is running on `staging.givewp.com`

### Changes of Note

1. Added `check_licenses` request handler which handles Give `2.5.0` responses provide all data back in a more efficient query as to not overburden the live website. 
2. Licensing now supports custom thumbnail images.
3. Licensing now supports custom banner images which appear under add-on detail thickbox modal.
4. Added additional checks to prevent invalid updates when a site has been migrated. The admin will only able to update the plugin if site registered on `givewp.com`.
5. `check_subscription` handler is now deprecated and Give 2.5.0+ does not use it. We now use license expiration dates as the source of truth. This is because often licenses get increased in expiration length due to promos, testing, or etc.
6. Added support for new All Access Passes. Requests now handle both types of licenses: existing single site licenses and the new All Access Pass activation functionality.